### PR TITLE
Remove leftover merge conflict resolution text from library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -2,13 +2,8 @@ name=Adaino
 version=0.1.0
 author=Werktag <opensource@werktag.io>
 maintainer=Andre Meyer <andmeyer@werktag.io>
-<<<<<<< HEAD
-sentence=An Analog Data Acquisition library for Arduino and IoT.
-paragraph=Adaino simplifies reading analog inputs not only for single conversion results but also for continuous signals with high frequency spectrums. Currently, only Arduino devices with an SAMD21 microcontroler as found in the Arduino MKR  or Adafruit Feather families are supported.
-=======
 sentence=An Analog Data Acquisition library for Arduino.
 paragraph=Adaino simplifies reading analog inputs at any sampling rate and cares about the proper acquisition thereof. Currently, only Arduino devices with an SAMD21 microcontroler as found in the Arduino MKR or Adafruit Feather families are supported.
->>>>>>> dev
 category=Signal Input/Output
 url=https://github.com/werktag/Adaino
 architectures=samd


### PR DESCRIPTION
Previously, after installing the library, all compilations in the Arduino IDE fail:
```
Error reading file (E:\arduino\libraries\Adaino\library.properties:4): Invalid line format, should be 'key=value'
```